### PR TITLE
ergo-node: 3.3.6 -> 3.3.7

### DIFF
--- a/nixpkgs/ergo-node/default.nix
+++ b/nixpkgs/ergo-node/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "ergo-node";
-  version = "3.3.6";
+  version = "3.3.7";
 
   src = fetchurl {
     url = "https://github.com/ergoplatform/ergo/releases/download/v${version}/ergo-${version}.jar";
-    sha256 = "1zi559ixjxxsrpvvjbxa1d0g96px3h9amjvy149sfhp7b8w5hhk3";
+    sha256 = "11gb372js4ybyxasi842ia34qlhkyn7xndi1dk3kpdd8g1jb8n1m";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Bump the node to latest release.