### PR TITLE
nixos: bump to 2020-12-24

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,8 @@
 {
 pkgs ? import (builtins.fetchTarball {
-    # NixOS 20.09 2020-11-13
-    url = "https://github.com/NixOS/nixpkgs/archive/896270d629efd47d14972e96f4fbb79fc9f45c80.tar.gz";
-    sha256 = "0xmjjayg19wm6cn88sh724mrsdj6mgrql6r3zc0g4x9bx4y342p7";
+    # NixOS 20.09 2020-12-24
+    url = "https://github.com/NixOS/nixpkgs/archive/a3a3dda3bacf61e8a39258a0ed9c924eeca8e293.tar.gz";
+    sha256 = "1ahn3srby9rjh7019b26n4rb4926di1lqdrclxfy2ff7nlf0yhd5";
   }) {},
 system ? builtins.currentSystem
 }:


### PR DESCRIPTION
Bumping NixOS 20.09 to latest commit.