### PR TITLE
ergo-explorer-backend: 4.0.1 -> 5.1.0, yoroi-ergo-backend: 20201121 -> 20201231

### DIFF
--- a/nixpkgs/ergo-explorer-backend/default.nix
+++ b/nixpkgs/ergo-explorer-backend/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "ergo-explorer-backend";
-  version = "4.0.1";
+  version = "5.1.0";
 
   src = fetchurl {
     url = "https://github.com/ergoplatform/explorer-backend/releases/download/${version}/explorer-${version}.tar.gz";
-    sha256 = "0cdkh8ms6gkwy66rm0cjzry8knpm5xgxhhqzqp94a9p72w25k875";
+    sha256 = "1m14ijvk586hz6xp7waxm0h0mh84bh4rnzznp6xamd1zibv7vdxs";
   };
 
   setSourceRoot = "sourceRoot=`pwd`";
@@ -16,10 +16,11 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/share/java
     cp -v *.jar $out/share/java/
-    makeWrapper ${jre}/bin/java $out/bin/ergo-chain-grabber --add-flags "-jar $out/share/java/ChainGrabber-assembly-${version}.jar"
-    makeWrapper ${jre}/bin/java $out/bin/ergo-explorer-api --add-flags "-jar $out/share/java/ExplorerApi-assembly-${version}.jar"
-    makeWrapper ${jre}/bin/java $out/bin/ergo-utx-broadcaster --add-flags "-jar $out/share/java/UtxBroadcaster-assembly-${version}.jar"
-    makeWrapper ${jre}/bin/java $out/bin/ergo-utx-tracker --add-flags "-jar $out/share/java/UtxTracker-assembly-${version}.jar"
+    makeWrapper ${jre}/bin/java $out/bin/ergo-chain-grabber --add-flags "-jar $out/share/java/ChainGrabber-${version}.jar"
+    makeWrapper ${jre}/bin/java $out/bin/ergo-explorer-api --add-flags "-jar $out/share/java/ExplorerApi-${version}.jar"
+    makeWrapper ${jre}/bin/java $out/bin/ergo-utx-broadcaster --add-flags "-jar $out/share/java/UtxBroadcaster-${version}.jar"
+    makeWrapper ${jre}/bin/java $out/bin/ergo-utx-tracker --add-flags "-jar $out/share/java/UtxTracker-${version}.jar"
+    makeWrapper ${jre}/bin/java $out/bin/ergo-migrator --add-flags "-jar $out/share/java/Migrator-${version}.jar"
   '';
 
 }

--- a/nixpkgs/yoroi-ergo-backend/default.nix
+++ b/nixpkgs/yoroi-ergo-backend/default.nix
@@ -13,13 +13,13 @@ let
 in buildNpmPackage rec {
 
   pname = "yoroi-ergo-backend";
-  version = "unstable-20201121";
+  version = "unstable-20201231";
 
   src = fetchFromGitHub {
     owner = "Emurgo";
     repo = "yoroi-ergo-backend";
-    rev = "373c3a1e28becc6739bba244f09c1a1597c2e5c4";
-    sha256 = "1l6jyadghmfsl9wjr5zr814a7baai6pgvws8gjagxnws8vp9ggz7";
+    rev = "e79e357922d6c91f0540228fc78918d21cd24214";
+    sha256 = "16ix362w5jl3qqfz72czqkh7vsd0p9h45l7c6y3bli4bn13ixxgd";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Bumping `ergo-explorer-backend` and `yoroi-ergo-backend`.